### PR TITLE
clientSettings pulls configuration from the URL... When connecting to…

### DIFF
--- a/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
+++ b/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
@@ -29,11 +29,7 @@ namespace IdentityServer4.MongoDB.DbContexts
                 clientSettings.SslSettings = settings.Value.SslSettings;
                 clientSettings.UseTls = true;
             }
-            else
-            {
-                clientSettings.UseTls = false;
-            }
-
+           
             _client = new MongoClient(clientSettings);
             Database = _client.GetDatabase(settings.Value.Database ?? mongoUrl.DatabaseName);
         }


### PR DESCRIPTION
… a url that is backed by ssl (MongoDB Atlas for example) if there is not a value for SslSettings, the required SSL configuration is forcibly removed from the configuration, which prevents the package from connecting to the SSL enabled endpoint as configured from the URL.